### PR TITLE
Add Prometheus+Grafana monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ O script principal `setup-wnc.sh` monta toda a stack com Nginx e certificados SS
 | `backup-setup.sh` | Agenda backup diário de Postgres, sessões WAHA e dados do n8n |
 | `restore-backup.sh` | Restaura dados do backup em caso de falha |
 | `maintenance_setup.sh` | Inicia Watchtower e cria `cron` semanal para `docker system prune` |
-| `monitoring_setup.sh` | Instala `node_exporter` e cAdvisor para coleta via Prometheus |
+| `monitoring_setup.sh` | Instala `htop`, `node_exporter`, `cAdvisor`, Prometheus e Grafana |
 | `check-services.sh` | Verifica portas abertas e testa as URLs públicas |
 | `nodejs-codex-installer.sh` | Instala Node.js LTS e as CLIs do Codex e Codebuff |
 | `manual_maintenance.sh` | Atualiza containers, renova SSL e checa dependências |
@@ -61,7 +61,8 @@ sudo ./maintenance_setup.sh
 ```
 
 ### monitoring_setup.sh
-Instala o node_exporter como serviço e executa o cAdvisor em container:
+Instala o `htop` para monitoramento rápido e sobe o stack Prometheus + Grafana \
+além dos exporters node_exporter e cAdvisor:
 ```bash
 sudo ./monitoring_setup.sh
 ```

--- a/monitoring_setup.sh
+++ b/monitoring_setup.sh
@@ -15,6 +15,12 @@ trap 'error "Linha $LINENO: comando \"$BASH_COMMAND\" falhou"' ERR
 
 [[ $EUID -eq 0 ]] || { error "Rode como root"; exit 1; }
 
+# Ferramenta simples ---------------------------------------------------------
+info "Instalando htop para monitoramento rápido…"
+apt-get update -y >/dev/null
+apt-get install -y htop >/dev/null
+info "Use 'htop' ou 'docker stats' para ver o consumo em tempo real."
+
 # node_exporter ---------------------------------------------------------------
 info "Instalando node_exporter…"
 useradd -rs /bin/false node_exporter 2>/dev/null || true
@@ -39,4 +45,41 @@ docker run -d --name=cadvisor --restart=unless-stopped \
   -p 8080:8080 -v /:/rootfs:ro -v /var/run:/var/run:ro \
   -v /sys:/sys:ro -v /var/lib/docker/:/var/lib/docker:ro \
   gcr.io/cadvisor/cadvisor:v0.49.1
-info "Monitoring up: node_exporter (9100) e cAdvisor (8080)."
+
+# Prometheus + Grafana --------------------------------------------------------
+info "Configurando Prometheus e Grafana via Docker Compose…"
+mkdir -p /opt/monitoring
+cat >/opt/monitoring/docker-compose.yml <<'EOF'
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+  grafana:
+    image: grafana/grafana:10.3.1
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+volumes:
+  prometheus-data:
+  grafana-data:
+EOF
+cat >/opt/monitoring/prometheus.yml <<'EOF'
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'node'
+    static_configs:
+      - targets: ['localhost:9100']
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['localhost:8080']
+EOF
+docker compose -f /opt/monitoring/docker-compose.yml up -d
+
+info "Monitoring up: node_exporter (9100), cAdvisor (8080), Prometheus (9090) e Grafana (3000)."


### PR DESCRIPTION
## Summary
- enhance `monitoring_setup.sh` to install `htop`
- deploy Prometheus and Grafana with docker compose
- document new monitoring tools in the README

## Testing
- `bash -n monitoring_setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685729bb084c8328877ceffe07c040a3