### PR TITLE
Add Fail2Ban setup automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ O script principal `setup-wnc.sh` monta toda a stack com Nginx e certificados SS
 | `setup-wnc.sh` | Instala Chatwoot, WAHA e n8n via Docker, configura Nginx e SSL |
 | `firewall-setup.sh` | Ativa UFW liberando 22/80/443 e bloqueando portas internas |
 | `security_hardening.sh` | Configura `unattended-upgrades`, ajusta SSH e instala Fail2Ban |
+| `fail2ban_setup.sh` | Instala e configura Fail2Ban (SSH e Nginx) |
 | `backup-setup.sh` | Agenda backup diário de Postgres, sessões WAHA e dados do n8n |
 | `restore-backup.sh` | Restaura dados do backup em caso de falha |
 | `maintenance_setup.sh` | Inicia Watchtower e cria `cron` semanal para `docker system prune` |
@@ -46,6 +47,12 @@ sudo ./firewall-setup.sh
 Aplica configurações de hardening de sistema e instala Fail2Ban:
 ```bash
 sudo ./security_hardening.sh
+```
+
+### fail2ban_setup.sh
+Instala e configura o Fail2Ban para monitorar acessos SSH e requisições Nginx:
+```bash
+sudo ./fail2ban_setup.sh
 ```
 
 ### backup-setup.sh

--- a/fail2ban_setup.sh
+++ b/fail2ban_setup.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Instala e configura Fail2Ban para proteger SSH e Nginx
+
+# Structured logging ----------------------------------------------------------
+SCRIPT_NAME=$(basename "$0" .sh)
+LOG_FILE="/var/log/${SCRIPT_NAME}.log"
+mkdir -p "$(dirname "$LOG_FILE")" && touch "$LOG_FILE"
+log() { local level="$1"; shift; echo "$(date '+%F %T') [$level] $*" | tee -a "$LOG_FILE"; }
+info() { log INFO "$@"; }
+warn() { log WARN "$@"; }
+error() { log ERROR "$@"; }
+
+set -Eeuo pipefail
+trap 'error "Linha $LINENO: comando \"$BASH_COMMAND\" falhou"' ERR
+
+[[ $EUID -eq 0 ]] || { error "Rode como root"; exit 1; }
+
+info "Instalando Fail2Ban…"
+apt-get update -qq
+apt-get install -y fail2ban >/dev/null
+
+info "Configurando jail.local…"
+cat >/etc/fail2ban/jail.local <<'JAIL'
+[DEFAULT]
+bantime = 1h
+findtime = 10m
+maxretry = 5
+
+[sshd]
+enabled = true
+port    = ssh
+logpath = /var/log/auth.log
+
+[nginx-http-auth]
+enabled = true
+port    = http,https
+logpath = /var/log/nginx/*access.log
+
+[nginx-botsearch]
+enabled = true
+port    = http,https
+logpath = /var/log/nginx/*access.log
+JAIL
+
+info "Ativando e iniciando serviço…"
+systemctl enable --now fail2ban
+
+fail2ban-client status sshd || true
+fail2ban-client status nginx-botsearch || true
+
+info "Fail2Ban configurado."


### PR DESCRIPTION
## Summary
- add `fail2ban_setup.sh` to configure SSH and Nginx jails
- document the new script in the README

## Testing
- `shellcheck fail2ban_setup.sh`
- `shellcheck security_hardening.sh fail2ban_setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_685729f4c6c88328a0d472ed6e81b0b3