### PR TITLE
Fix Chatwoot db image

### DIFF
--- a/setup-wnc.sh
+++ b/setup-wnc.sh
@@ -144,7 +144,7 @@ services:
     networks: [$STACK_NET]
     restart: always
   postgres:
-    image: postgres:13
+    image: pgvector/pgvector:pg13
     environment:
       POSTGRES_USER: chatwoot
       POSTGRES_PASSWORD: chatwoot


### PR DESCRIPTION
## Summary
- use `pgvector` image for Chatwoot Postgres

## Testing
- `shellcheck setup-wnc.sh`

------
https://chatgpt.com/codex/tasks/task_e_68573462d234832896043ebcbe734e7d