### PR TITLE
Add SSL and HTTPS checks to maintenance script

### DIFF
--- a/manual_maintenance.sh
+++ b/manual_maintenance.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
-# Atualiza imagens Docker, renova certificados SSL e verifica dependências
-set -euo pipefail
-log(){ echo -e "\e[36m[MANUT]\e[0m $*"; }
+# Atualiza imagens Docker, renova certificados SSL e valida HTTPS
+
+set -Eeuo pipefail
+trap 'echo "[ERRO] Linha $LINENO: comando \"$BASH_COMMAND\" falhou" >&2' ERR
+
+log() { echo -e "\e[36m[MANUT]\e[0m $*"; }
+
 [[ $EUID -eq 0 ]] || { echo "[ERRO] Rode como root"; exit 1; }
 
-declare -a DEPS=(docker certbot)
+declare -a DEPS=(docker certbot curl openssl)
 log "Verificando dependências..."
 for dep in "${DEPS[@]}"; do
   if ! command -v "$dep" &>/dev/null; then
@@ -13,6 +17,33 @@ for dep in "${DEPS[@]}"; do
   fi
   "$dep" --version | head -n1
 done
+
+# Domínios utilizados nos testes
+DOMAINS=(
+  "chat.saraivavision.com.br"
+  "waha.saraivavision.com.br"
+  "n8n.saraivavision.com.br"
+)
+
+# Verifica validade do certificado SSL de um domínio
+check_cert() {
+  local domain=$1
+  if expiry=$(openssl s_client -connect "$domain:443" -servername "$domain" -CAfile /etc/ssl/certs/ca-certificates.crt </dev/null 2>/dev/null \
+    | openssl x509 -noout -enddate); then
+    log "Certificado de $domain expira em ${expiry#*=}"
+  else
+    log "[ERRO] Falha ao validar certificado de $domain"
+  fi
+}
+
+# Testa acesso HTTPS de um domínio
+test_https() {
+  local domain=$1
+  local url="https://$domain"
+  local code
+  code=$(curl -ks -o /dev/null -w '%{http_code}' "$url" || true)
+  log "$url -> HTTP $code"
+}
 
 log "Atualizando containers Docker..."
 for compose in /opt/chatwoot/docker-compose.yml \
@@ -28,5 +59,11 @@ done
 log "Renovando certificados SSL..."
 certbot renew --quiet
 systemctl reload nginx
+
+log "Validando certificados e HTTPS..."
+for domain in "${DOMAINS[@]}"; do
+  check_cert "$domain"
+  test_https "$domain"
+done
 
 log "Manutenção concluída."


### PR DESCRIPTION
## Summary
- improve manual maintenance script to validate SSL certificates and HTTPS

## Testing
- `shellcheck manual_maintenance.sh`


------
https://chatgpt.com/codex/tasks/task_e_68573b06fdec8328ad06dd7445d8dd0f