### PR TITLE
Add enable-http script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ configurados com seus próprios domínios.
 | `check-services.sh` | Verifica portas abertas e testa as URLs públicas |
 | `nodejs-codex-installer.sh` | Instala Node.js LTS e as CLIs do Codex e Codebuff |
 | `manual_maintenance.sh` | Atualiza containers, renova SSL e checa dependências |
+| `enable-http.sh` | Remove redirecionamentos HTTPS para liberar acesso HTTP |
 | `update-images.sh` | Atualiza as imagens Docker para versões específicas |
 
 

--- a/enable-http.sh
+++ b/enable-http.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Remove redirecionamentos HTTPS para habilitar acesso via HTTP
+
+set -Eeuo pipefail
+trap 'echo "[ERRO] Linha $LINENO: comando \"$BASH_COMMAND\" falhou" >&2' ERR
+
+[[ $EUID -eq 0 ]] || { echo "[ERRO] Rode como root"; exit 1; }
+
+domains=(
+  "chat.saraivavision.com.br"
+  "waha.saraivavision.com.br"
+  "n8n.saraivavision.com.br"
+)
+
+for d in "${domains[@]}"; do
+  conf="/etc/nginx/sites-available/${d}"
+  if [[ -f $conf ]]; then
+    if grep -q "return 301" "$conf"; then
+      sed -i '/return 301/d' "$conf"
+      echo "[INFO] Redirecionamento removido em $conf"
+    else
+      echo "[INFO] Nenhum redirecionamento encontrado em $conf"
+    fi
+  else
+    echo "[WARN] Arquivo $conf inexistente" >&2
+  fi
+done
+
+nginx -t && systemctl reload nginx
+
+echo "Acesso HTTP liberado."


### PR DESCRIPTION
## Summary
- add `enable-http.sh` to remove HTTPS redirects
- document new script in README

## Testing
- `shellcheck enable-http.sh`


------
https://chatgpt.com/codex/tasks/task_e_6857bdf7af148328a7290decc8f77bf5